### PR TITLE
Update package.json so the discord.js version issue is resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
 	},
 	"dependencies": {
 		"axios": "1.6.3",
-		"axios-retry": "^3.9.1",
-		"chalk": "^4.1.2",
-		"discord.js": "^14.14.1",
-		"js-yaml": "^4.1.0"
+		"axios-retry": "3.9.1",
+		"chalk": "4.1.2",
+		"discord.js": "14.14.1",
+		"js-yaml": "4.1.0"
 	},
 	"engines": {
 		"node": ">=16.9.0"


### PR DESCRIPTION
The package.json had these little `^` which for some reason downloaded the latest version of all packages but removing them will fix it and download the specific Discord.JS version and prevent this error:

```Unsupported "discord.js" version!.
Please delete your "node_modules" and "package-lock.json".
And restart the bot.
Please make sure to check and remove "npm install" command from your startup params.
```