### PR TITLE
`chore`: remove the `^` in the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
         "start": "node index.js"
     },
     "dependencies": {
-        "axios": "^1.7.7",
-        "cli-color": "^2.0.4",
-        "discord.js": "^14.16.1",
-        "dotenv": "^16.4.5",
-        "js-yaml": "^4.1.0"
+        "axios": "1.7.7",
+        "cli-color": "2.0.4",
+        "discord.js": "14.16.1",
+        "dotenv": "16.4.5",
+        "js-yaml": "4.1.0"
     },
     "engines": {
         "node": ">=18"


### PR DESCRIPTION
necessary for the packages not to break