### PR TITLE
`chore`: update license from 2022 to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 HirziDevs
+Copyright (c) 2024 HirziDevs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
license was back in 2022, this pr updates it